### PR TITLE
ci: use path filters to avoid running long tests for e.g. docs changes

### DIFF
--- a/.github/workflows/fv3_translate_tests.yaml
+++ b/.github/workflows/fv3_translate_tests.yaml
@@ -3,6 +3,13 @@ name: "FV3 translate tests"
 # Run these these whenever ...
 on:
   pull_request: # ... a PR is opened / updated
+    paths-ignore:
+      - '.github/**/*.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'internal/**'
+      - 'zensical.toml'
+      - 'README.md'
   merge_group: # ... the PR is added to the merge queue
   push:
     branches:

--- a/.github/workflows/pace_tests.yaml
+++ b/.github/workflows/pace_tests.yaml
@@ -3,6 +3,13 @@ name: "pace main tests"
 # Run these these whenever ...
 on:
   pull_request: # ... a PR is opened / updated
+    paths-ignore:
+      - '.github/**/*.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'internal/**'
+      - 'zensical.toml'
+      - 'README.md'
   merge_group: # ... the PR is added to the merge queue
   push:
     branches:

--- a/.github/workflows/shield_tests.yaml
+++ b/.github/workflows/shield_tests.yaml
@@ -3,6 +3,13 @@ name: "SHiELD Translate tests"
 # Run these these whenever ...
 on:
   pull_request: # ... a PR is opened / updated
+    paths-ignore:
+      - '.github/**/*.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'internal/**'
+      - 'zensical.toml'
+      - 'README.md'
   merge_group: # ... the PR is added to the merge queue
   push:
     branches:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -3,6 +3,13 @@ name: "NDSL unit tests"
 # Run these these whenever ...
 on:
   pull_request: # ... a PR is opened / updated
+    paths-ignore:
+      - '.github/**/*.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'internal/**'
+      - 'zensical.toml'
+      - 'README.md'
   merge_group: # ... the PR is added to the merge queue
   push:
     branches:


### PR DESCRIPTION
This PR introduces simple path ignore filters and applies them to "long running" workflows. This is very coarse-grained and just skips entire workflows for docs / markdown only changes. In particular, any changes that only touch files matched by these filters

- '.github/**/*.md'
- 'docs/**'
- 'examples/**'
- 'internal/**'
- 'zensical.toml'
- 'README.md'

will skip the following pipelines (on pull requests)

- NDSL unit tests
- pyFV3 translate tests
- pySHiELD translate tests
- pace translate tests
